### PR TITLE
fix: blinking on Android

### DIFF
--- a/.changeset/mighty-carrots-worry.md
+++ b/.changeset/mighty-carrots-worry.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix(android): tab bar label blinking on select

--- a/packages/react-native-bottom-tabs/android/build.gradle
+++ b/packages/react-native-bottom-tabs/android/build.gradle
@@ -117,7 +117,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.google.android.material:material:1.13.0-alpha06'
+  implementation 'com.google.android.material:material:1.13.0-alpha09'
 
   implementation("io.coil-kt.coil3:coil:${COIL_VERSION}")
   implementation("io.coil-kt.coil3:coil-network-okhttp:${COIL_VERSION}")


### PR DESCRIPTION
## PR Description

This PR fixes blinking when selecting items on Android when all labels are shown. 

## Screenshots

### Before


https://github.com/user-attachments/assets/6f2b9819-0e59-410d-83d0-4a80be298fbf



### After


https://github.com/user-attachments/assets/bb2ebaa3-de94-45f8-be65-4dd2cf0a91cb

