### PR TITLE
chore: remove tsc path from package.json

### DIFF
--- a/packages/react-native-bottom-tabs/package.json
+++ b/packages/react-native-bottom-tabs/package.json
@@ -105,8 +105,7 @@
         "typescript",
         {
           "project": "tsconfig.build.json",
-          "esm": true,
-          "tsc": "../../node_modules/.bin/tsc"
+          "esm": true
         }
       ]
     ]

--- a/packages/react-navigation/package.json
+++ b/packages/react-navigation/package.json
@@ -103,8 +103,7 @@
         "typescript",
         {
           "project": "tsconfig.build.json",
-          "esm": true,
-          "tsc": "../../node_modules/.bin/tsc"
+          "esm": true
         }
       ]
     ]


### PR DESCRIPTION
## PR Description

Removes hardcoded `tsc` path from `package.json`, as without it it is still being resolved correctly and packages build as expected

## How to test?

Green CI, `yarn build` works correctly

