### PR TITLE
fix: fix tabLabelStyle not applying on android

### DIFF
--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -370,7 +370,7 @@ class ReactBottomNavigationView(context: ReactContext) : LinearLayout(context) {
 
   private fun updateTextAppearance() {
     if (fontSize != null || fontFamily != null || fontWeight != null) {
-      val menuView = getChildAt(0) as? ViewGroup ?: return
+      val menuView = bottomNavigation.getChildAt(0) as? ViewGroup ?: return
       val size = fontSize?.toFloat()?.takeIf { it > 0 } ?: 12f
       val typeface = ReactFontManager.getInstance().getTypeface(
         fontFamily ?: "",


### PR DESCRIPTION
## PR Description

tabLabelStyle is not applied on android currently in the latest release, this fixes this issue so that custom font and font size changes will correctly apply.

## How to test?

Change fontSize in the tabLabelStyle within the NativeBottomTabs route, pre this commit it did not do anything.

