### PR TITLE
fix: fix crash on iOS when adding fontWeight on old arch builds

### DIFF
--- a/packages/react-native-bottom-tabs/ios/Fabric/RCTTabViewComponentView.mm
+++ b/packages/react-native-bottom-tabs/ios/Fabric/RCTTabViewComponentView.mm
@@ -156,7 +156,7 @@ using namespace facebook::react;
   }
   
   if (oldViewProps.fontWeight != newViewProps.fontWeight) {
-    _tabViewProvider.fontWeigth = RCTNSStringFromStringNilIfEmpty(newViewProps.fontWeight);
+    _tabViewProvider.fontWeight = RCTNSStringFromStringNilIfEmpty(newViewProps.fontWeight);
   }
   
   if (oldViewProps.fontFamily != newViewProps.fontFamily) {

--- a/packages/react-native-bottom-tabs/ios/TabViewProvider.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewProvider.swift
@@ -145,9 +145,9 @@ public final class TabInfo: NSObject {
     }
   }
 
-  @objc public var fontWeigth: NSString? {
+  @objc public var fontWeight: NSString? {
     didSet {
-      props.fontWeight = fontWeigth as? String
+      props.fontWeight = fontWeight as? String
     }
   }
 


### PR DESCRIPTION
## PR Description

Fixes crash when adding fontWeight as a label style on iOS, when built using old architecture

## How to test?

Create build with new arch disabled, and add fontWeight as a label style.

## Screenshots

![Simulator Screenshot - iPhone 16 Pro - 2025-01-22 at 21 00 34](https://github.com/user-attachments/assets/6a63276f-20fc-44a9-b8c9-52a87140ffc1)
