### PR TITLE
fix(iOS): properly handle measurements by ignoring keyboard

### DIFF
--- a/.changeset/orange-deers-stare.md
+++ b/.changeset/orange-deers-stare.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: properly handle measurements by ignoring keyboard

--- a/packages/react-native-bottom-tabs/ios/Extensions.swift
+++ b/packages/react-native-bottom-tabs/ios/Extensions.swift
@@ -97,7 +97,7 @@ extension View {
               onLayout(geometry.size)
             }
         }
-          .ignoresSafeArea(.container, edges: .vertical)
+        .ignoresSafeArea(.all, edges: .vertical)
       )
   }
 }


### PR DESCRIPTION
## PR Description

This PR should fix issues with keyboard shifting layout: #266, https://github.com/callstackincubator/react-native-bottom-tabs/discussions/255

## How to test?

Open keyboard

## Screenshots


https://github.com/user-attachments/assets/f75c85b1-d490-44ec-a18a-8ebae7261d60

