### PR TITLE
fix(android): first screen being blank

### DIFF
--- a/.changeset/angry-dingos-hug.md
+++ b/.changeset/angry-dingos-hug.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: first screen is blank

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -80,7 +80,7 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
     ))
 
     post {
-      layoutHolder.addOnLayoutChangeListener { _, left, top, right, bottom,
+      addOnLayoutChangeListener { _, left, top, right, bottom,
                                   _, _, _, _ ->
         val newWidth = right - left
         val newHeight = bottom - top


### PR DESCRIPTION
This PR fixes the regression introduced in the latest release. Fixing this issue: #282 
