### PR TITLE
fix: upgrade material to alpha10 so dynamic tabBarIcon works on Material 3

### DIFF
--- a/.changeset/funny-oranges-applaud.md
+++ b/.changeset/funny-oranges-applaud.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+chore: bump android material components package

--- a/packages/react-native-bottom-tabs/android/build.gradle
+++ b/packages/react-native-bottom-tabs/android/build.gradle
@@ -112,7 +112,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.google.android.material:material:1.13.0-alpha09'
+  implementation 'com.google.android.material:material:1.13.0-alpha10'
 
   implementation("io.coil-kt.coil3:coil:${COIL_VERSION}")
   implementation("io.coil-kt.coil3:coil-network-okhttp:${COIL_VERSION}")


### PR DESCRIPTION
When using a app theme with a Material 3 parent theme a dynamic `tabBarIcon` based on `focused` stopped working in version 0.8.0. This change fixes this