### PR TITLE
fix: remove video url from packages's `README.md`

### DIFF
--- a/packages/react-native-bottom-tabs/README.md
+++ b/packages/react-native-bottom-tabs/README.md
@@ -15,8 +15,6 @@
 
 </div>
 
-https://github.com/user-attachments/assets/fbdd9ce2-f4b9-4d0c-bd91-2e62bb422d69
-
 ## Documentation
 
 The full documentation can be found on our [website](https://okwasniewski.github.io/react-native-bottom-tabs/).


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

Remove video url from the `package`'s README.md file because npm don't render it properly

![CleanShot 2025-02-10 at 14 57 48@2x](https://github.com/user-attachments/assets/55d122b2-9cef-4d19-a4d8-b295911621f6)

There's another README.md in the root of this directory which still will contain nice looking video :D 

## How to test?

n/a

## Screenshots

n/a
