### PR TITLE
fix(ios): prevent header showing on iPad when using a custom one

### DIFF
--- a/.changeset/purple-beers-laugh.md
+++ b/.changeset/purple-beers-laugh.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: prevent header showing on iPad when using a custom one

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -101,6 +101,7 @@ struct TabViewImpl: View {
         }
         .tag(tabData?.key)
         .tabBadge(tabData?.badge)
+        .hideTabBar(props.tabBarHidden)
         .onAppear {
 #if !os(macOS)
           updateTabBarAppearance(props: props, tabBar: tabBar)
@@ -346,6 +347,20 @@ extension View {
         self.tint(color)
       } else {
         self.accentColor(color)
+      }
+    } else {
+      self
+    }
+  }
+  
+  @ViewBuilder
+  func hideTabBar(_ flag: Bool) -> some View {
+    if flag {
+      if #available(iOS 16.0, *) {
+        self.toolbar(.hidden, for: .tabBar)
+      } else {
+        // We fallback to isHidden on UITabBar
+        self
       }
     } else {
       self


### PR DESCRIPTION
## PR Description

This PR resolves #293 


## How to test?

Use custom header

## Screenshots

![CleanShot 2025-02-10 at 17 19 43@2x](https://github.com/user-attachments/assets/2aebbb77-c94a-4bdb-890f-b1f2aa01f05c)
