### PR TITLE
fix: shutdown ImageLoader onDropViewInstance on android

### DIFF
--- a/.changeset/lucky-dots-cheat.md
+++ b/.changeset/lucky-dots-cheat.md
@@ -1,0 +1,5 @@
+---
+"react-native-bottom-tabs": patch
+---
+
+fix: propery destroy image loader on Android

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -384,6 +384,10 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
     updateTextAppearance()
   }
 
+  fun onDropViewInstance() {
+    imageLoader.shutdown()
+  }
+
   private fun updateTextAppearance() {
     if (fontSize != null || fontFamily != null || fontWeight != null) {
       val menuView = bottomNavigation.getChildAt(0) as? ViewGroup ?: return
@@ -454,10 +458,5 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
     addView(bottomNavigation)
     updateItems(items)
     uiModeConfiguration = newConfig?.uiMode ?: uiModeConfiguration
-  }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    imageLoader.shutdown()
   }
 }

--- a/packages/react-native-bottom-tabs/android/src/newarch/RCTTabViewManager.kt
+++ b/packages/react-native-bottom-tabs/android/src/newarch/RCTTabViewManager.kt
@@ -43,6 +43,11 @@ class RCTTabViewManager(context: ReactApplicationContext) :
 
   }
 
+  override fun onDropViewInstance(view: ReactBottomNavigationView) {
+    super.onDropViewInstance(view)
+    view.onDropViewInstance()
+  }
+
   override fun getName(): String {
     return tabViewImpl.getName()
   }

--- a/packages/react-native-bottom-tabs/android/src/oldarch/RCTTabViewManager.kt
+++ b/packages/react-native-bottom-tabs/android/src/oldarch/RCTTabViewManager.kt
@@ -39,6 +39,11 @@ class RCTTabViewManager(context: ReactApplicationContext) : ViewGroupManager<Rea
     return view
   }
 
+  override fun onDropViewInstance(view: ReactBottomNavigationView) {
+    super.onDropViewInstance(view)
+    view.onDropViewInstance()
+  }
+
   override fun getChildCount(parent: ReactBottomNavigationView): Int {
     return tabViewImpl.getChildCount(parent)
   }


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

`imageLoader.shutdown()` is called `onDetachedFromWindow`. But this lifecycle method is called when opening a modal on top of the current view containing bottom tabs. When then closing the modal the `ImageLoader` has been shutdown and wont load icons anymore. Solved this by checking if `imageLoader` is null in the `getDrawable` method and if so creates it again.

Fixes #309 

## How to test?

1. Download fork at https://github.com/johankasperi/react-native-bottom-tabs/tree/android-modal-tabbaricon-bug
2. Run example app on Android
3. Open "Embedded Stacks" example
4. Open the modal and close it again
5. Change between the tabs and see that the icon changes when they are focused
