### PR TITLE
fix: add tvOS 16.0 availability check for toolbar API

### DIFF
--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -354,7 +354,7 @@ extension View {
   @ViewBuilder
   func hideTabBar(_ flag: Bool) -> some View {
     if flag {
-      if #available(iOS 16.0, *) {
+      if #available(iOS 16.0, tvOS 16.0, *) {
         self.toolbar(.hidden, for: .tabBar)
       } else {
         // We fallback to isHidden on UITabBar


### PR DESCRIPTION
Problem:
The toolbar API availability check only includes iOS 16.0, causing build errors on tvOS targets. This was introduced by https://github.com/callstackincubator/react-native-bottom-tabs/commit/024e92e2708eb076079d9eedddb79eeae4c2af9e#diff-89822b2e0d1364951af03c6bbf9b4e69b7e1f1ceca81ad7b242d48ba2195e5a3R355-R368

<img width="724" alt="image" src="https://github.com/user-attachments/assets/4e965cd7-a2ae-4181-bced-c2dda5c6ecf1" />


Solution:
Added tvOS 16.0 to the availability check to support both platforms.