### PR TITLE
Provide alternative to enabling static framework on Expo using expo-build-properties

### DIFF
--- a/docs/docs/docs/getting-started/quick-start.mdx
+++ b/docs/docs/docs/getting-started/quick-start.mdx
@@ -84,6 +84,28 @@ You also need to enable static linking for iOS by adding `"useFrameworks": "stat
 }
 ```
 
+Alternatively, you can avoid enabling static linking (which can cause problems with your existing packages) by adding the following in the `expo-build-properties` plugin.
+
+```diff
+{
+  "expo": {
+    "plugins": [
+       "react-native-bottom-tabs",
++      [
++        "expo-build-properties",
++        {
++          "ios": {
++            "extraPods": [
++              { name: "SDWebImage", modular_headers: true }, // Work around for not enabling static framework, required for react-native-bottom-tabs
++              { name: "SDWebImageSVGCoder", modular_headers: true }
++            ]
++          }
++        }
++      ]
++    ]
+  }
+}
+```
 
 :::warning
 


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

Current docs specify static framework linking must be enabled for installation, however it is possible to just use expo-build-properties to specify the 2 pods that require modular_headers support to be installed as extra pods (which was the reason why static framework linking had to be enabled in the first place). 

The extraPods option appears to implement essentially the code in the following podfile without having to enable static linking in Expo 

https://github.com/callstackincubator/react-native-bottom-tabs/blob/1b0ed94579bb234afc047a0bae7f2463cb125de0/example/ios/Podfile

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->

Docs update

<!-- Please provide the steps to test the changes you made. -->

Just do a fresh new build 
