### PR TITLE
fix: don't crash when no elements are found

### DIFF
--- a/.changeset/metal-rocks-shop.md
+++ b/.changeset/metal-rocks-shop.md
@@ -1,0 +1,5 @@
+---
+"react-native-bottom-tabs": patch
+---
+
+fix(android): don't crash when no elements are found

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -423,7 +423,7 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
 
   private fun updateTintColors() {
     // First let's check current item color.
-    val currentItemTintColor = items.first { it.key == selectedItem }.activeTintColor
+    val currentItemTintColor = items.firstOrNull { it.key == selectedItem }?.activeTintColor
 
     // getDefaultColor will always return a valid color but to satisfy the compiler we need to check for null
     val colorPrimary = currentItemTintColor ?: activeTintColor ?: Utils.getDefaultColorFor(


### PR DESCRIPTION
## PR Description

This PR uses `.firstOrNull` instead of `.first` which doesn't throw an exception.

