### PR TITLE
feat: Support more than 6 screens on Android

### DIFF
--- a/.changeset/giant-years-turn.md
+++ b/.changeset/giant-years-turn.md
@@ -1,0 +1,5 @@
+---
+"react-native-bottom-tabs": patch
+---
+
+feat: support more than 6 screens on Android

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -36,7 +36,7 @@ import com.google.android.material.transition.platform.MaterialFadeThrough
 
 class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
   override fun getMaxItemCount(): Int {
-    return 1_000
+    return 100
   }
 }
 

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -34,6 +34,12 @@ import com.google.android.material.navigation.NavigationBarView.LABEL_VISIBILITY
 import com.google.android.material.navigation.NavigationBarView.LABEL_VISIBILITY_UNLABELED
 import com.google.android.material.transition.platform.MaterialFadeThrough
 
+class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
+  override fun getMaxItemCount(): Int {
+    return 1_000
+  }
+}
+
 class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
   private var bottomNavigation = ExtendedBottomNavigationView(context)
   val layoutHolder = FrameLayout(context)
@@ -462,11 +468,5 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
     setLabeled(this.labeled)
     this.selectedItem?.let { setSelectedItem(it) }
     uiModeConfiguration = newConfig?.uiMode ?: uiModeConfiguration
-  }
-}
-
-class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
-  override fun getMaxItemCount(): Int {
-    return 1_000
   }
 }

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -35,7 +35,7 @@ import com.google.android.material.navigation.NavigationBarView.LABEL_VISIBILITY
 import com.google.android.material.transition.platform.MaterialFadeThrough
 
 class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
-  private var bottomNavigation = BottomNavigationView(context)
+  private var bottomNavigation = ExtendedBottomNavigationView(context)
   val layoutHolder = FrameLayout(context)
 
   var onTabSelectedListener: ((key: String) -> Unit)? = null
@@ -456,11 +456,17 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
     // React Native opts out ouf Activity re-creation when configuration changes, this workarounds that.
     // We also opt-out of this recreation when custom styles are used.
     removeView(bottomNavigation)
-    bottomNavigation = BottomNavigationView(context)
+    bottomNavigation = ExtendedBottomNavigationView(context)
     addView(bottomNavigation)
     updateItems(items)
     setLabeled(this.labeled)
     this.selectedItem?.let { setSelectedItem(it) }
     uiModeConfiguration = newConfig?.uiMode ?: uiModeConfiguration
+  }
+}
+
+class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
+  override fun getMaxItemCount(): Int {
+    return 1_000
   }
 }

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -162,7 +162,7 @@ interface Props<Route extends BaseRoute> {
   };
 }
 
-const ANDROID_MAX_TABS = 1_000;
+const ANDROID_MAX_TABS = 100;
 
 const TabView = <Route extends BaseRoute>({
   navigationState,

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -162,7 +162,7 @@ interface Props<Route extends BaseRoute> {
   };
 }
 
-const ANDROID_MAX_TABS = 6;
+const ANDROID_MAX_TABS = 1_000;
 
 const TabView = <Route extends BaseRoute>({
   navigationState,


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description
The default maximum number of screens allowed by Android's bottom navigation view is 6. I think the reasoning is to prevent people from over-populating the bottom tab bar. However, there are two situations that I can think of that require more than 6 tabs:

1. You have a custom tab bar and just want to use the native transition animations
2. You are explicitly hiding some tabs from the tab bar, but still want to be able to navigate to other screens and have the nav bar visible.

The goal isn't to make the nav bar look ugly, but provide more flexibility for "hidden" screens or custom tab bars.

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->

## How to test?
Update the example app to have more than 6 screens and see them all appear in the bottom tab bar. Make some screens hidden from the tab bar but still provide a way to navigate to them (maybe add a button on one of the screens that navigates to this "hidden" screen). You should see the native animation still works.

<!-- Please provide the steps to test the changes you made. -->

## Screenshots
<img width="427" alt="Screenshot 2025-04-11 at 2 19 10 PM" src="https://github.com/user-attachments/assets/1c0f01db-7389-4813-8fa3-3cccee604bdf" />

<!-- If applicable, add screenshots or videos to help explain your changes. -->
