### PR TITLE
fix: set initial size fill full screen

### DIFF
--- a/.changeset/all-dryers-study.md
+++ b/.changeset/all-dryers-study.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: set initial size to full screen

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -7,6 +7,7 @@ import type {
 } from './TabViewNativeComponent';
 import {
   type ColorValue,
+  type DimensionValue,
   Image,
   Platform,
   StyleSheet,
@@ -198,8 +199,8 @@ const TabView = <Route extends BaseRoute>({
   const customTabBarWrapperRef = useRef<View>(null);
   const [tabBarHeight, setTabBarHeight] = React.useState<number | undefined>(0);
   const [measuredDimensions, setMeasuredDimensions] = React.useState<
-    { width: number; height: number } | undefined
-  >();
+    { width: DimensionValue; height: DimensionValue } | undefined
+  >({ width: '100%', height: '100%' });
 
   const trimmedRoutes = React.useMemo(() => {
     if (


### PR DESCRIPTION
## PR Description

This PR sets the initial size to be (100%, 100%) before the event is emitted.

## How to test?

Check the `onLayout` calls.

## Screenshots

N/A