### PR TITLE
docs: add note about transformers like react-native-svg-transformer

### DIFF
--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -244,6 +244,39 @@ Function that given `{ focused: boolean }` returns `ImageSource` or `AppleIcon` 
 SF Symbols are only supported on Apple platforms.
 :::
 
+:::warning
+
+Metro transformers that modify the import resolutions of images to something that is *not* React Native's `ImageSource` will break this. A notable community example of such is [react-native-svg-transformer](https://github.com/kristerkari/react-native-svg-transformer).
+
+For best results, avoid the use of such transformers altogether.
+
+If however, it is necessary to use such a transformer, you can modify your `metro.config.js` file to resolve the asset to `ImageSource` with another extension.
+
+For example, with `react-native-svg-transformer`, you can resolve the `svg` extension to use `react-native-svg-transformer`, and use an alternative extension like `svgx` to resolve it normally with React Native's default behavior.
+
+To do so, change the extension of your icon SVG file from `.svg` to `.svgx` and modify your `metro.config.js` file like so:
+
+```diff
+config.transformer.babelTransformerPath = require.resolve(
+  "react-native-svg-transformer"
+);
+config.resolver.assetExts = config.resolver.assetExts.filter(
+  (ext) => ext !== "svg"
+);
+
++ config.resolver.assetExts = [...config.resolver.assetExts, "svgx"];
+
+config.resolver.sourceExts = [...config.resolver.sourceExts, "svg"];
+```
+
+Then change your require calls like so:
+```
+tabBarIcon: () => require('person.svgx')
+```
+
+:::
+
+
 #### `tabBarBadge`
 
 Badge to show on the tab icon.


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

`react-native-svg-transformer` is a popular transformer that plenty of people in the RN ecosystem use to import SVGs as React components. This transformer however, breaks SVG usage in this library.

This is not the fault of this library, rather more so on the transformer as it's modifying the default behavior of React Native's (more specifically Metro's) asset handling.

However, as this approach is quite popular, it makes sense adding a note in the docs about it. There's two parts to the warning: first, informing the end user that such transformers will break this functionality. I also added an example of how to resolve this with `react-native-svg-transformer` specifically as it's quite a popular lib. `react-native-svg-transformer` unfortunately overrides the `svg` extension specifically and does not give you an option to change the extension it's overriding (so no `svg?react` for example 😞), so my proposed solution uses another extension that resolves the SVG to Metro's standard resolution of SVGs and uses that in the code for the `tabBarIcon`.

Existing GitHub issue showing people struggling with this: https://github.com/callstackincubator/react-native-bottom-tabs/issues/143#issuecomment-2479561808

Cheers, and thanks for this amazing library!

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->



## How to test?

<!-- Please provide the steps to test the changes you made. -->

N/A

## Screenshots

<!-- If applicable, add screenshots or videos to help explain your changes. -->

N/A
