### PR TITLE
feat: add Tab api support on newer OS

### DIFF
--- a/packages/react-native-bottom-tabs/ios/TabView/LegacyTabView.swift
+++ b/packages/react-native-bottom-tabs/ios/TabView/LegacyTabView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct LegacyTabView: View {
+  @ObservedObject var props: TabViewProps
+
+#if os(macOS)
+  var tabBar: NSTabView?
+#else
+  var tabBar: UITabBar?
+#endif
+  
+  var onLayout: (_ size: CGSize) -> Void
+  var onSelect: (_ key: String) -> Void
+  var updateTabBarAppearance: (_ props: TabViewProps, _ tabBar: UITabBar?) -> Void
+  
+  @ViewBuilder
+  var body: some View {
+    TabView(selection: $props.selectedPage) {
+      ForEach(props.children.indices, id: \.self) { index in
+        renderTabItem(at: index)
+      }
+      .measureView { size in
+        onLayout(size)
+      }
+    }
+    .hideTabBar(props.tabBarHidden)
+  }
+  
+  @ViewBuilder
+  private func renderTabItem(at index: Int) -> some View {
+    if let tabData = props.items[safe: index] {
+      let isFocused = props.selectedPage == tabData.key
+      
+      if !tabData.hidden || isFocused {
+        let icon = props.icons[index]
+        let child = props.children[safe: index] ?? PlatformView()
+        
+        RepresentableView(view: child)
+          .ignoresSafeArea(.container, edges: .all)
+          .tabItem {
+            TabItem(
+              title: tabData.title,
+              icon: icon,
+              sfSymbol: tabData.sfSymbol,
+              labeled: props.labeled
+            )
+            .accessibilityIdentifier(tabData.testID ?? "")
+            .tag(tabData.key)
+            .tabBadge(tabData.badge)
+            .onAppear {
+#if !os(macOS)
+              updateTabBarAppearance(props, tabBar)
+#endif
+#if os(iOS)
+              if index >= 4, !isFocused {
+                onSelect(tabData.key)
+              }
+#endif
+            }
+          }
+      }
+    }
+  }
+}

--- a/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
+++ b/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+@available(iOS 18, macOS 15, visionOS 2, tvOS 18, *)
+struct NewTabView: View {
+  @ObservedObject var props: TabViewProps
+  @AppStorage("sidebarCustomizations") var tabViewCustomization: TabViewCustomization
+
+  #if os(macOS)
+    var tabBar: NSTabView?
+  #else
+    var tabBar: UITabBar?
+  #endif
+
+  var onLayout: (_ size: CGSize) -> Void
+  var onSelect: (_ key: String) -> Void
+  var updateTabBarAppearance: (_ props: TabViewProps, _ tabBar: UITabBar?) -> Void
+
+  @ViewBuilder
+  var body: some View {
+    TabView(selection: $props.selectedPage) {
+      ForEach(props.children.indices, id: \.self) { index in
+        if let tabData = props.items[safe: index] {
+          let isFocused = props.selectedPage == tabData.key
+
+          if !tabData.hidden || isFocused {
+            let icon = props.icons[index]
+            let role: TabRole? = nil
+
+            let platformChild = props.children[safe: index] ?? PlatformView()
+            let child = RepresentableView(view: platformChild)
+
+            Tab(value: tabData.key, role: role) {
+              child
+                .ignoresSafeArea(.container, edges: .all)
+                .onAppear {
+                  #if !os(macOS)
+                    updateTabBarAppearance(props, tabBar)
+                  #endif
+                  #if os(iOS)
+                    if index >= 4 {
+                      if props.selectedPage != tabData.key {
+                        onSelect(tabData.key)
+                      }
+                    }
+                  #endif
+                }
+            } label: {
+              TabItem(
+                title: tabData.title,
+                icon: icon,
+                sfSymbol: tabData.sfSymbol,
+                labeled: props.labeled
+              )
+            }
+            //.badge(tabData.badge)
+            .customizationID(tabData.key)
+            .customizationBehavior(.disabled, for: .sidebar, .tabBar)
+            .accessibilityIdentifier(tabData.testID ?? "")
+          }
+        }
+      }
+    }
+    .measureView { size in
+      onLayout(size)
+    }
+    .tabViewCustomization($tabViewCustomization)
+    .hideTabBar(props.tabBarHidden)
+  }
+}


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->

This pr adds support for the new swift [Tab](https://developer.apple.com/documentation/swiftui/tab) api on ios/ipadOS/tvOS 18+, macOS 15+ and visionOS 2+. This let us implement many new features (such as [search role](https://developer.apple.com/documentation/swiftui/tabrole/search) for the tab item, [tabbar customization](https://developer.apple.com/documentation/swiftui/tabcontent/customizationbehavior(_:for:)), [swipe actions](https://developer.apple.com/documentation/swiftui/tabcontent/swipeactions(edge:allowsfullswipe:content:)) and [context menus](https://developer.apple.com/documentation/swiftui/tabcontent/contextmenu(menuitems:))), while also opening up an opportunity to implement https://github.com/callstackincubator/react-native-bottom-tabs/discussions/296 in the future.

---

In order to implement it i had to create a separate file for each implementation because only by doing so and using `@available(iOS 18, macOS 15, visionOS 2, tvOS 18, *)` on `NewTabView` i could then add  `@AppStorage("sidebarCustomizations")`. I tried to maintain every feature on each implementation and moved the `TabViewImpl#renderTabItem` to `LegacyTabView#renderTabItem`. i was hoping to add a similar function to the NewTabView struct but in that case the Tab api gave an error about not conforming to View (strange since the same code works directly in the ForEach).

As of now i have disabled customization for each Tab (using `.customizationBehavior(.disabled, for: .sidebar, .tabBar)`), as we can then discuss in a followup pr/issue the js implementation, set Tab role to nil (same reason), disabled badges on the new tab (commented line) because even if `tabData.badge` is an empty string, an empty red dot is created, and i could not figure out how to circumvent this. Finally, i found a strange behaviour with the `Native Bottom Tabs with Custom Tab Bar` example, where for the new tab implementation, the native tab is still visible, but even there i could not figure out why.

Let me know your thoughts and if you have any suggestion on how to resolve these issues

## How to test?

<!-- Please provide the steps to test the changes you made. -->

Open the app and test the examples

## Screenshots

<!-- If applicable, add screenshots or videos to help explain your changes. -->

N/A, the look is the same, only a new edit button has appeared in the ipad/macos sidebar