### PR TITLE
Apply typeface and size individually in android text appearance.

### DIFF
--- a/.changeset/bright-windows-sip.md
+++ b/.changeset/bright-windows-sip.md
@@ -1,0 +1,5 @@
+---
+"react-native-bottom-tabs": patch
+---
+
+fix: apply typeface and size individually in android text appearance.

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -399,27 +399,34 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
   }
 
   private fun updateTextAppearance() {
-    if (fontSize != null || fontFamily != null || fontWeight != null) {
-      val menuView = bottomNavigation.getChildAt(0) as? ViewGroup ?: return
-      val size = fontSize?.toFloat()?.takeIf { it > 0 } ?: 12f
-      val typeface = ReactFontManager.getInstance().getTypeface(
+    // Early return if there is no custom text appearance
+    if (fontSize == null && fontFamily == null && fontWeight == null) {
+      return
+    }
+
+    val typeface = if (fontFamily != null || fontWeight != null) {
+      ReactFontManager.getInstance().getTypeface(
         fontFamily ?: "",
         Utils.getTypefaceStyle(fontWeight),
         context.assets
       )
+    } else null
+    val size = fontSize?.toFloat()?.takeIf { it > 0 }
 
-      for (i in 0 until menuView.childCount) {
-        val item = menuView.getChildAt(i)
-        val largeLabel =
-          item.findViewById<TextView>(com.google.android.material.R.id.navigation_bar_item_large_label_view)
-        val smallLabel =
-          item.findViewById<TextView>(com.google.android.material.R.id.navigation_bar_item_small_label_view)
+    val menuView = bottomNavigation.getChildAt(0) as? ViewGroup ?: return
+    for (i in 0 until menuView.childCount) {
+      val item = menuView.getChildAt(i)
+      val largeLabel =
+        item.findViewById<TextView>(com.google.android.material.R.id.navigation_bar_item_large_label_view)
+      val smallLabel =
+        item.findViewById<TextView>(com.google.android.material.R.id.navigation_bar_item_small_label_view)
 
-        listOf(largeLabel, smallLabel).forEach { label ->
-          label?.apply {
+      listOf(largeLabel, smallLabel).forEach { label ->
+        label?.apply {
+          size?.let { size ->
             setTextSize(TypedValue.COMPLEX_UNIT_SP, size)
-            setTypeface(typeface)
           }
+          typeface?.let { setTypeface(it) }
         }
       }
     }


### PR DESCRIPTION
When using a custom font with bottom tabs today on Android, another font size is also set by default. With the biggest difference from the standard one being that it scales with the system font scale, which the default one does not. 

## PR Description

**Improvement**: This splits the application of text appearance, so that size and typeface(family and weight) is applied individually. So that when setting one or the other, only that is applied. So one could use a custom font family, without getting the font scaling which is usually not wanted with tab bars.

## How to test?

On Android apply `fontFamily`+`fontWeight` and `fontSize` individually in `tabLabelStyle`, and see they can be used individually.

## Screenshots

Before and after examples with bigger system font scale on Android
| Code | Before | After |
|--------|--------|--------|
|<img width="317" height="163" alt="Screenshot 2025-07-25 at 09 14 29" src="https://github.com/user-attachments/assets/28d46b46-ff43-43ff-be71-95c1f2fb6621" /> | <img width="456" height="139" alt="Screenshot 2025-07-25 at 09 03 36" src="https://github.com/user-attachments/assets/151e597a-680f-4905-bdfc-6884dbb6c51f" /> | <img width="467" height="147" alt="Screenshot 2025-07-25 at 08 55 09" src="https://github.com/user-attachments/assets/153d0060-567d-4c82-bcd1-a3485e4ed36e" /> |
| <img width="294" height="174" alt="Screenshot 2025-07-25 at 09 13 50" src="https://github.com/user-attachments/assets/e258768a-1685-4842-a3db-23698027d193" />| <img width="452" height="126" alt="Screenshot 2025-07-25 at 08 56 25" src="https://github.com/user-attachments/assets/15977c9b-2116-46c4-878a-8bf7067f6a16" /> | (same as before) <img width="452" height="126" alt="Screenshot 2025-07-25 at 08 56 25" src="https://github.com/user-attachments/assets/15977c9b-2116-46c4-878a-8bf7067f6a16" /> | 









