### PR TITLE
fix: iOS 26 switching animation delay

### DIFF
--- a/.changeset/eight-ducks-rest.md
+++ b/.changeset/eight-ducks-rest.md
@@ -1,0 +1,6 @@
+---
+'react-native-bottom-tabs': minor
+'@bottom-tabs/react-navigation': minor
+---
+
+feat: introduce preventsDefault option

--- a/apps/example/src/Examples/NativeBottomTabs.tsx
+++ b/apps/example/src/Examples/NativeBottomTabs.tsx
@@ -66,14 +66,14 @@ function NativeBottomTabs() {
         name="Contacts"
         component={Contacts}
         listeners={{
-          tabPress: (e) => {
-            e.preventDefault();
+          tabPress: () => {
             console.log('Contacts tab press prevented');
           },
         }}
         options={{
           tabBarIcon: () => require('../../assets/icons/person_dark.png'),
           tabBarActiveTintColor: 'yellow',
+          preventsDefault: true,
         }}
       />
       <Tab.Screen

--- a/docs/docs/docs/guides/standalone-usage.md
+++ b/docs/docs/docs/guides/standalone-usage.md
@@ -214,6 +214,7 @@ Each route in the `routes` array can have the following properties:
 - `freezeOnBlur`: Whether to freeze the tab's content when it's not visible
 - `role`: A value that defines the purpose of the tab
 - `style`: Style object for the component wrapping the screen content
+- `preventsDefault`: Whether to prevent default tab switching behavior when pressed
 
 ### Helper Props
 
@@ -274,3 +275,9 @@ Function to get the role for a tab item.
 Function to get the style for a tab scene.
 
 - Default: Uses `route.style`
+
+#### `getPreventsDefault`
+
+Function to determine if a tab should prevent default switching behavior when pressed.
+
+- Default: Uses `route.preventsDefault`

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -53,6 +53,7 @@ export default function App() {
           component={SettingsScreen}
           options={{
             tabBarIcon: () => ({ sfSymbol: 'gear' }),
+            preventsDefault: true, // Prevents automatic tab switching
           }}
         />
       </Tab.Navigator>
@@ -321,6 +322,17 @@ Boolean indicating whether to prevent inactive screens from re-rendering. Defaul
 
 It's working separately from `enableFreeze()` in `react-native-screens`. So settings won't be shared between them.
 
+#### `preventsDefault`
+
+Whether to prevent default tab switching behavior when this tab is pressed. This is useful when you want to handle tab press events manually without switching tabs.
+
+- Type: `boolean`
+- Default: `false`
+
+:::note
+Due to iOS 26's new tab switching animations, controlling tab switching from JavaScript can cause significant delays. The `preventsDefault` option allows you to define this behavior statically to avoid animation delays.
+:::
+
 
 #### `tabBarButtonTestID`
 
@@ -361,9 +373,9 @@ To prevent the default behavior, you can call `event.preventDefault`:
 ```tsx
 React.useEffect(() => {
   const unsubscribe = navigation.addListener('tabPress', (e) => {
-    // Prevent default behavior
-    e.preventDefault();
-
+    // Note: For iOS 26+, use the `preventsDefault` option instead of `e.preventDefault()`
+    // to avoid animation delays
+    
     // Do something manually
     // ...
   });

--- a/packages/react-native-bottom-tabs/ios/Fabric/RCTTabViewComponentView.mm
+++ b/packages/react-native-bottom-tabs/ios/Fabric/RCTTabViewComponentView.mm
@@ -38,7 +38,8 @@ bool operator==(const RNCTabViewItemsStruct& lhs, const RNCTabViewItemsStruct& r
   lhs.activeTintColor == rhs.activeTintColor &&
   lhs.hidden == rhs.hidden &&
   lhs.testID == rhs.testID &&
-  lhs.role == rhs.role;
+  lhs.role == rhs.role &&
+  lhs.preventsDefault == rhs.preventsDefault;
 }
 
 bool operator!=(const RNCTabViewItemsStruct& lhs, const RNCTabViewItemsStruct& rhs) {
@@ -189,7 +190,9 @@ NSArray* convertItemsToArray(const std::vector<RNCTabViewItemsStruct>& items) {
                                 activeTintColor:RCTUIColorFromSharedColor(item.activeTintColor)
                                          hidden:item.hidden
                                          testID:RCTNSStringFromStringNilIfEmpty(item.testID)
-                                         role:RCTNSStringFromStringNilIfEmpty(item.role)];
+                                         role:RCTNSStringFromStringNilIfEmpty(item.role)
+                              preventsDefault:item.preventsDefault
+    ];
 
     [result addObject:tabInfo];
   }

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -44,7 +44,7 @@ struct TabViewImpl: View {
       #if !os(tvOS) && !os(macOS) && !os(visionOS)
         .onTabItemEvent { index, isLongPress in
           let item = props.filteredItems[safe: index]
-          guard let key = item?.key else { return }
+          guard let key = item?.key else { return false }
 
           if isLongPress {
             onLongPress(key)
@@ -53,6 +53,7 @@ struct TabViewImpl: View {
             onSelect(key)
             emitHapticFeedback()
           }
+          return item?.preventsDefault ?? false
         }
       #endif
       .introspectTabView { tabController in

--- a/packages/react-native-bottom-tabs/ios/TabViewProvider.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewProvider.swift
@@ -14,6 +14,7 @@ public final class TabInfo: NSObject {
   public let hidden: Bool
   public let testID: String?
   public let role: TabBarRole?
+  public let preventsDefault: Bool
 
   public init(
     key: String,
@@ -23,7 +24,8 @@ public final class TabInfo: NSObject {
     activeTintColor: PlatformColor?,
     hidden: Bool,
     testID: String?,
-    role: String?
+    role: String?,
+    preventsDefault: Bool = false
   ) {
     self.key = key
     self.title = title
@@ -33,6 +35,7 @@ public final class TabInfo: NSObject {
     self.hidden = hidden
     self.testID = testID
     self.role = TabBarRole(rawValue: role ?? "")
+    self.preventsDefault = preventsDefault
     super.init()
   }
 }
@@ -288,7 +291,8 @@ public final class TabInfo: NSObject {
             activeTintColor: RCTConvert.uiColor(itemDict["activeTintColor"] as? NSNumber),
             hidden: itemDict["hidden"] as? Bool ?? false,
             testID: itemDict["testID"] as? String ?? "",
-            role: itemDict["role"] as? String
+            role: itemDict["role"] as? String,
+            preventsDefault: itemDict["preventsDefault"] as? Bool ?? false
           )
         )
       }

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -108,6 +108,10 @@ interface Props<Route extends BaseRoute> {
    */
   getActiveTintColor?: (props: { route: Route }) => ColorValue | undefined;
   /**
+   * Determines whether the tab prevents default action (switching tabs) on press, uses `route.preventsDefault` by default.
+   */
+  getPreventsDefault?: (props: { route: Route }) => boolean | undefined;
+  /**
    * Get icon for the tab, uses `route.focusedIcon` by default.
    */
   getIcon?: (props: {
@@ -204,6 +208,7 @@ const TabView = <Route extends BaseRoute>({
   getTestID = ({ route }: { route: Route }) => route.testID,
   getRole = ({ route }: { route: Route }) => route.role,
   getSceneStyle = ({ route }: { route: Route }) => route.style,
+  getPreventsDefault = ({ route }: { route: Route }) => route.preventsDefault,
   hapticFeedbackEnabled = false,
   // Android's native behavior is to show labels when there are less than 4 tabs. We leave it as undefined to use the platform default behavior.
   labeled = Platform.OS !== 'android' ? true : undefined,
@@ -276,6 +281,7 @@ const TabView = <Route extends BaseRoute>({
           hidden: getHidden?.({ route }),
           testID: getTestID?.({ route }),
           role: getRole?.({ route }),
+          preventsDefault: getPreventsDefault?.({ route }),
         };
       }),
     [
@@ -287,6 +293,7 @@ const TabView = <Route extends BaseRoute>({
       getHidden,
       getTestID,
       getRole,
+      getPreventsDefault,
     ]
   );
 

--- a/packages/react-native-bottom-tabs/src/TabViewNativeComponent.ts
+++ b/packages/react-native-bottom-tabs/src/TabViewNativeComponent.ts
@@ -31,6 +31,7 @@ export type TabViewItems = ReadonlyArray<{
   hidden?: boolean;
   testID?: string;
   role?: string;
+  preventsDefault?: boolean;
 }>;
 
 export interface TabViewProps extends ViewProps {

--- a/packages/react-native-bottom-tabs/src/types.ts
+++ b/packages/react-native-bottom-tabs/src/types.ts
@@ -20,6 +20,7 @@ export type BaseRoute = {
   role?: TabRole;
   freezeOnBlur?: boolean;
   style?: StyleProp<ViewStyle>;
+  preventsDefault?: boolean;
 };
 
 export type NavigationState<Route extends BaseRoute> = {

--- a/packages/react-navigation/src/types.ts
+++ b/packages/react-navigation/src/types.ts
@@ -106,6 +106,10 @@ export type NativeBottomTabNavigationOptions = {
    * Style object for the component wrapping the screen content.
    */
   sceneStyle?: StyleProp<ViewStyle>;
+  /**
+   * Whether to prevent default action of the tab. Defaults to `false`.
+   */
+  preventsDefault?: boolean;
 };
 
 export type NativeBottomTabDescriptor = Descriptor<
@@ -145,6 +149,7 @@ export type NativeBottomTabNavigationConfig = Partial<
     | 'tabBar'
     | 'getFreezeOnBlur'
     | 'getSceneStyle'
+    | 'getPreventsDefault'
   >
 > & {
   tabBar?: (props: BottomTabBarProps) => React.ReactNode;

--- a/packages/react-navigation/src/views/NativeBottomTabView.tsx
+++ b/packages/react-navigation/src/views/NativeBottomTabView.tsx
@@ -79,6 +79,9 @@ export default function NativeBottomTabView({
           target: route.key,
         });
       }}
+      getPreventsDefault={({ route }) =>
+        descriptors[route.key]?.options.preventsDefault
+      }
       onIndexChange={(index) => {
         const route = state.routes[index];
         if (!route) {
@@ -91,7 +94,10 @@ export default function NativeBottomTabView({
           canPreventDefault: true,
         });
 
-        if (event.defaultPrevented) {
+        if (
+          event.defaultPrevented ||
+          descriptors[route.key]?.options.preventsDefault
+        ) {
           return;
         } else {
           navigation.dispatch({


### PR DESCRIPTION
## PR Description

This PR should close #383

To support this it was required to change the api slightly. Now whether the tab prevents default has to be defined in options:

```tsx
options={{
          tabBarIcon: () => require('../../assets/icons/person_dark.png'),
          preventsDefault: true,
        }}
```

This ensures animations are smooth while still keeping the possibility to override what a given tab is doing. 


https://github.com/user-attachments/assets/426e0d32-69d2-4dc4-b144-f72d4316dee6

