### PR TITLE
fix(tabbar): replace TabRole with TabBarRole to resolve iOS build error

### DIFF
--- a/packages/react-native-bottom-tabs/ios/TabViewProps.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewProps.swift
@@ -27,7 +27,7 @@ public enum TabBarRole: String {
   case search
 
   @available(iOS 18, macOS 15, visionOS 2, tvOS 18, *)
-  func convert() -> TabRole {
+  func convert() -> TabBarRole {
     switch self {
       case .search:
         return .search


### PR DESCRIPTION
- Updated convert() to return TabBarRole instead of TabRole
- Fixes iOS build error caused by incorrect type