### PR TITLE
fix: show small badge on Android when passing empty space

### DIFF
--- a/.changeset/shy-masks-accept.md
+++ b/.changeset/shy-masks-accept.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: show small badge on Android when passing empty space

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -248,7 +248,11 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
       if (item.badge?.isNotEmpty() == true) {
         val badge = bottomNavigation.getOrCreateBadge(index)
         badge.isVisible = true
-        badge.text = item.badge
+        // Set the badge text only if it's different than an empty space to show a small badge.
+        // More context: https://github.com/callstackincubator/react-native-bottom-tabs/issues/422
+        if (item.badge != " ") {
+          badge.text = item.badge
+        }
       } else {
         bottomNavigation.removeBadge(index)
       }


### PR DESCRIPTION
## PR Description

This PR shows a small badge when passing an empty string to show just a dot.

Closes #422

<img width="712" height="198" alt="CleanShot 2025-10-01 at 21 41 31@2x" src="https://github.com/user-attachments/assets/451da0f6-0767-47d8-bef8-1692a44af0e8" />
