### PR TITLE
fix: properly pop to top

### DIFF
--- a/.changeset/calm-singers-scream.md
+++ b/.changeset/calm-singers-scream.md
@@ -1,0 +1,6 @@
+---
+'react-native-bottom-tabs': minor
+'@bottom-tabs/react-navigation': minor
+---
+
+fix: properly pop to top to resolve freezing issues

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -1748,7 +1748,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-bottom-tabs (1.0.3):
+  - react-native-bottom-tabs (1.0.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1766,7 +1766,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-bottom-tabs/common (= 1.0.3)
+    - react-native-bottom-tabs/common (= 1.0.5)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1778,7 +1778,7 @@ PODS:
     - SocketRocket
     - SwiftUIIntrospect (~> 1.0)
     - Yoga
-  - react-native-bottom-tabs/common (1.0.3):
+  - react-native-bottom-tabs/common (1.0.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2461,7 +2461,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNScreens (4.16.0):
+  - RNScreens (4.18.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2488,10 +2488,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.16.0)
+    - RNScreens/common (= 4.18.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.16.0):
+  - RNScreens/common (4.18.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2842,7 +2842,7 @@ SPEC CHECKSUMS:
   React-logger: a3cb5b29c32b8e447b5a96919340e89334062b48
   React-Mapbuffer: 9d2434a42701d6144ca18f0ca1c4507808ca7696
   React-microtasksnativemodule: 75b6604b667d297292345302cc5bfb6b6aeccc1b
-  react-native-bottom-tabs: 9a6f606d07e2e46f2535f1faed915fcb2d4f0269
+  react-native-bottom-tabs: 8e918142554e3878f043b23bdf93049b34a78ca6
   react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
   React-NativeModulesApple: 879fbdc5dcff7136abceb7880fe8a2022a1bd7c3
   React-oscompat: 93b5535ea7f7dff46aaee4f78309a70979bdde9d
@@ -2878,7 +2878,7 @@ SPEC CHECKSUMS:
   ReactTestApp-DevSupport: 9b7bbba5e8fed998e763809171d9906a1375f9d3
   ReactTestApp-Resources: 4f6dff3b157f879757cd750caccd1d34a7eda647
   RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
-  RNScreens: 0bbf16c074ae6bb1058a7bf2d1ae017f4306797c
+  RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
   RNVectorIcons: c13cc1db346e960ecd0aafcdd5d0bb458133b9c1
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@bottom-tabs/react-navigation": "*",
     "@react-navigation/bottom-tabs": "^7.4.7",
+    "@react-navigation/devtools": "^7.0.44",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.26",
     "@react-navigation/stack": "^7.4.8",
@@ -24,7 +25,7 @@
     "react-native-gesture-handler": "^2.28.0",
     "react-native-paper": "^5.14.5",
     "react-native-safe-area-context": "^5.6.1",
-    "react-native-screens": "^4.16.0",
+    "react-native-screens": "^4.18.0",
     "react-native-vector-icons": "^10.2.0"
   },
   "devDependencies": {

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -12,7 +12,11 @@ import {
   Alert,
   Platform,
 } from 'react-native';
-import { NavigationContainer, useNavigation } from '@react-navigation/native';
+import {
+  NavigationContainer,
+  useNavigation,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -31,6 +35,7 @@ import NativeBottomTabsUnmounting from './Examples/NativeBottomTabsUnmounting';
 import NativeBottomTabsCustomTabBar from './Examples/NativeBottomTabsCustomTabBar';
 import NativeBottomTabsFreezeOnBlur from './Examples/NativeBottomTabsFreezeOnBlur';
 import BottomAccessoryView from './Examples/BottomAccessoryView';
+import { useLogger } from '@react-navigation/devtools';
 
 const HiddenTab = () => {
   return <FourTabs hideOneTab />;
@@ -194,9 +199,13 @@ export default function Navigation() {
 
   const NavigationStack = mode === 'js' ? Stack : NativeStack;
 
+  const navigationRef = useNavigationContainerRef();
+
+  useLogger(navigationRef);
+
   return (
     <SafeAreaProvider>
-      <NavigationContainer>
+      <NavigationContainer ref={navigationRef}>
         <NavigationStack.Navigator initialRouteName="BottomTabs Example">
           <NavigationStack.Screen
             name="BottomTabs Example"

--- a/packages/react-native-bottom-tabs/ios/TabItemEventModifier.swift
+++ b/packages/react-native-bottom-tabs/ios/TabItemEventModifier.swift
@@ -17,6 +17,16 @@ private final class TabBarDelegate: NSObject, UITabBarControllerDelegate {
     }
 #endif
 
+    let isReselectingSameTab = tabBarController.selectedViewController == viewController
+
+    if isReselectingSameTab {
+      if let index = tabBarController.viewControllers?.firstIndex(of: viewController) {
+        _ = onClick?(index)
+      }
+
+      return false
+    }
+
     // Unfortunately, due to iOS 26 new tab switching animations, controlling state from JavaScript is causing significant delays when switching tabs.
     // See: https://github.com/callstackincubator/react-native-bottom-tabs/issues/383
     // Due to this, whether the tab prevents default has to be defined statically.

--- a/packages/react-navigation/src/views/NativeBottomTabView.tsx
+++ b/packages/react-navigation/src/views/NativeBottomTabView.tsx
@@ -89,6 +89,7 @@ export default function NativeBottomTabView({
         descriptors[route.key]?.options.preventsDefault
       }
       onIndexChange={(index) => {
+        const focused = index === state.index;
         const route = state.routes[index];
         if (!route) {
           return;
@@ -101,6 +102,7 @@ export default function NativeBottomTabView({
         });
 
         if (
+          focused ||
           event.defaultPrevented ||
           descriptors[route.key]?.options.preventsDefault
         ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5614,6 +5614,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-navigation/devtools@npm:^7.0.44":
+  version: 7.0.44
+  resolution: "@react-navigation/devtools@npm:7.0.44"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    nanoid: "npm:^3.3.11"
+    stacktrace-parser: "npm:^0.1.11"
+  peerDependencies:
+    react: ">= 18.2.0"
+  checksum: 10/67f7f7ebac0e222437b78cd3dc7d7ac5a00bad706809b18f02ceec716a077e7d5a851cbe6573fbd4828d9b4b6001f1b81564f28c705977581a6b6f080672ff3a
+  languageName: node
+  linkType: hard
+
 "@react-navigation/elements@npm:^2.6.4":
   version: 2.6.4
   resolution: "@react-navigation/elements@npm:2.6.4"
@@ -15950,6 +15963,7 @@ __metadata:
     "@react-native/metro-config": "npm:0.81.4"
     "@react-native/typescript-config": "npm:0.81.4"
     "@react-navigation/bottom-tabs": "npm:^7.4.7"
+    "@react-navigation/devtools": "npm:^7.0.44"
     "@react-navigation/native": "npm:^7.1.17"
     "@react-navigation/native-stack": "npm:^7.3.26"
     "@react-navigation/stack": "npm:^7.4.8"
@@ -15965,7 +15979,7 @@ __metadata:
     react-native-gesture-handler: "npm:^2.28.0"
     react-native-paper: "npm:^5.14.5"
     react-native-safe-area-context: "npm:^5.6.1"
-    react-native-screens: "npm:^4.16.0"
+    react-native-screens: "npm:^4.18.0"
     react-native-test-app: "npm:^4.4.10"
     react-native-vector-icons: "npm:^10.2.0"
   languageName: unknown
@@ -16130,6 +16144,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/f055d37b3abf96f42c15d61645441995884ed69b2a6b35f63a21abeb147b9df7e084447d2a329a424ee3686d703c25817ea588d3be9e6ebc38e5c653ebe5e05b
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:^4.18.0":
+  version: 4.18.0
+  resolution: "react-native-screens@npm:4.18.0"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/456c18069ab8fee1d6c341d6bd13cba477fcda10f266844fb5f486ad5ac2c7336a5181956e261be010318be53585d4a72fd9bd00289117bbbdea681309de21f4
   languageName: node
   linkType: hard
 
@@ -17764,7 +17791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stacktrace-parser@npm:^0.1.10":
+"stacktrace-parser@npm:^0.1.10, stacktrace-parser@npm:^0.1.11":
   version: 0.1.11
   resolution: "stacktrace-parser@npm:0.1.11"
   dependencies:


### PR DESCRIPTION
## PR Description

This PR eliminates freezes when popping to top.

Should fix: #464, #461

Now native bottom tabs emit exact same events as JS bottom tabs.

