### PR TITLE
fix: exclude macOS from iOS 26+ bottom accessory APIs

### DIFF
--- a/.changeset/cold-mice-fold.md
+++ b/.changeset/cold-mice-fold.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+fix: macos bottom accessory view compilation

--- a/packages/react-native-bottom-tabs/ios/BottomAccessoryProvider.swift
+++ b/packages/react-native-bottom-tabs/ios/BottomAccessoryProvider.swift
@@ -8,6 +8,7 @@ import SwiftUI
     self.delegate = delegate
   }
 
+  #if !os(macOS)
   @available(iOS 26.0, *)
   public func emitPlacementChanged(_ placement: TabViewBottomAccessoryPlacement?) {
     var placementValue = "none"
@@ -18,6 +19,7 @@ import SwiftUI
     }
     self.delegate?.onPlacementChanged(placement: placementValue)
   }
+  #endif
 }
 
 @objc public protocol BottomAccessoryProviderDelegate {

--- a/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
+++ b/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
@@ -67,7 +67,11 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
   }
 
   func body(content: Content) -> some View {
-    if #available(iOS 26.0, macOS 26.0, tvOS 26.0, visionOS 3.0, *), bottomAccessoryView != nil {
+    #if os(macOS)
+    // tabViewBottomAccessory is not available on macOS
+    content
+    #else
+    if #available(iOS 26.0, tvOS 26.0, visionOS 3.0, *), bottomAccessoryView != nil {
       content
         .tabViewBottomAccessory {
           renderBottomAccessoryView()
@@ -75,18 +79,22 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
     } else {
       content
     }
+    #endif
   }
 
   @ViewBuilder
   private func renderBottomAccessoryView() -> some View {
+    #if !os(macOS)
     if let bottomAccessoryView {
       if #available(iOS 26.0, *) {
         BottomAccessoryRepresentableView(view: bottomAccessoryView)
       }
     }
+    #endif
   }
 }
 
+#if !os(macOS)
 @available(iOS 26.0, *)
 struct BottomAccessoryRepresentableView: PlatformViewRepresentable {
   @Environment(\.tabViewBottomAccessoryPlacement) var tabViewBottomAccessoryPlacement
@@ -115,3 +123,4 @@ struct BottomAccessoryRepresentableView: PlatformViewRepresentable {
     }
   }
 }
+#endif


### PR DESCRIPTION
## PR Description

Closes #484

Fixes macOS compilation errors by excluding iOS 26+ tabViewBottomAccessory APIs that don't exist on macOS