### PR TITLE
feat(ios): add ignoresContentBackground prop for iOS 26 liquid glass control

### DIFF
--- a/packages/react-native-bottom-tabs/ios/RCTTabViewComponentView.mm
+++ b/packages/react-native-bottom-tabs/ios/RCTTabViewComponentView.mm
@@ -180,6 +180,9 @@ using namespace facebook::react;
     _tabViewProvider.tabBarHidden = newViewProps.tabBarHidden;
   }
 
+  if (oldViewProps.ignoresContentBackground != newViewProps.ignoresContentBackground) {
+    _tabViewProvider.ignoresContentBackground = newViewProps.ignoresContentBackground;
+  }
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -45,6 +45,7 @@ struct TabViewImpl: View {
   var body: some View {
     tabContent
       .tabBarMinimizeBehavior(props.minimizeBehavior)
+      .ignoresContentBackground(props.ignoresContentBackground, barTintColor: props.barTintColor)
       #if !os(tvOS) && !os(macOS) && !os(visionOS)
         .onTabItemEvent { index, isLongPress in
           let item = props.filteredItems[safe: index]
@@ -324,5 +325,27 @@ extension View {
     } else {
       self
     }
+  }
+
+  /// Disables iOS 26 liquid glass content sampling and uses a solid background instead.
+  /// When enabled, the tab bar will use the specified barTintColor (or system default if nil)
+  /// instead of dynamically sampling colors from the content behind it.
+  @ViewBuilder
+  func ignoresContentBackground(_ ignores: Bool, barTintColor: PlatformColor?) -> some View {
+    #if compiler(>=6.2)
+    if #available(iOS 26.0, *) {
+      if ignores {
+        self
+          .toolbarBackgroundVisibility(.visible, for: .tabBar)
+          .toolbarBackground(barTintColor.map { Color($0) } ?? Color(.systemBackground), for: .tabBar)
+      } else {
+        self
+      }
+    } else {
+      self
+    }
+    #else
+      self
+    #endif
   }
 }

--- a/packages/react-native-bottom-tabs/ios/TabViewProps.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewProps.swift
@@ -71,6 +71,7 @@ class TabViewProps: ObservableObject {
   @Published var fontFamily: String?
   @Published var fontWeight: String?
   @Published var tabBarHidden: Bool = false
+  @Published var ignoresContentBackground: Bool = false
 
   var selectedActiveTintColor: PlatformColor? {
     if let selectedPage,

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -212,6 +212,18 @@ interface Props<Route extends BaseRoute> {
    * @default 'locale'
    */
   layoutDirection?: LayoutDirection;
+  /**
+   * When true, disables iOS 26 liquid glass content sampling and uses a solid
+   * background color (from tabBarStyle.backgroundColor) instead of dynamically
+   * sampling colors from the content behind the tab bar. (iOS 26+ only)
+   *
+   * Use this when you have dynamic content (like maps) where the liquid glass
+   * effect causes the tab bar to have inconsistent or unreadable colors.
+   *
+   * @platform ios
+   * @default false
+   */
+  ignoresContentBackground?: boolean;
 }
 
 const ANDROID_MAX_TABS = 100;

--- a/packages/react-native-bottom-tabs/src/TabViewNativeComponent.ts
+++ b/packages/react-native-bottom-tabs/src/TabViewNativeComponent.ts
@@ -61,6 +61,7 @@ export interface TabViewProps extends ViewProps {
   fontFamily?: string;
   fontWeight?: string;
   fontSize?: Int32;
+  ignoresContentBackground?: boolean;
 }
 
 export default codegenNativeComponent<TabViewProps>('RNCTabView', {


### PR DESCRIPTION
## Summary

iOS 26 introduced a new "liquid glass" material effect for tab bars that dynamically samples colors from the content behind it. While this creates beautiful translucent effects for static content, it can cause readability issues when the content is dynamic (like maps) or has varying colors.

This PR adds a new `ignoresContentBackground` prop that, when set to true, disables the liquid glass content sampling on iOS 26+ and instead uses a solid background color (from `tabBarStyle.backgroundColor` / `barTintColor`).

## Usage

With standalone TabView:
```tsx
<TabView
  tabBarStyle={{ backgroundColor: 'black' }}
  ignoresContentBackground={true}
  // ... other props
/>
```

With @bottom-tabs/react-navigation:
```tsx
<Tab.Navigator
  tabBarStyle={{ backgroundColor: 'black' }}
  ignoresContentBackground={true}
>
  {/* screens */}
</Tab.Navigator>
```

## Implementation

- Added `ignoresContentBackground` prop to `TabViewNativeComponent.ts` (codegen)
- Added `ignoresContentBackground` to `TabViewProps.swift`
- Added prop bridging in `RCTTabViewComponentView.mm`
- Added SwiftUI `.toolbarBackgroundVisibility(.visible)` and `.toolbarBackground()` modifiers for iOS 26+ in `TabViewImpl.swift`
- Added JSDoc documentation in `TabView.tsx`

## Platform Support

This prop only has an effect on iOS 26+. On earlier iOS versions and other platforms, it is ignored.

## Motivation

When displaying dynamic content like maps behind the tab bar, the liquid glass effect samples various colors from the map, causing the tab bar to have inconsistent or hard-to-read colors. This prop provides a way to opt-out of the liquid glass sampling while maintaining the glass material appearance with a fixed tint color.

## Test Plan

- [ ] Test on iOS 26 simulator/device with `ignoresContentBackground={true}` - tab bar should show solid background
- [ ] Test on iOS 26 with `ignoresContentBackground={false}` (default) - liquid glass should work normally
- [ ] Test on iOS < 26 - prop should have no effect
- [ ] Test with various `tabBarStyle.backgroundColor` values