### PR TITLE
Guard iOS 26 APIs for compatibility with Xcode 16.x

### DIFF
--- a/packages/react-native-bottom-tabs/ios/BottomAccessoryProvider.swift
+++ b/packages/react-native-bottom-tabs/ios/BottomAccessoryProvider.swift
@@ -8,7 +8,7 @@ import SwiftUI
     self.delegate = delegate
   }
 
-  #if !os(macOS)
+  #if compiler(>=6.1) && !os(macOS)
   @available(iOS 26.0, *)
   public func emitPlacementChanged(_ placement: TabViewBottomAccessoryPlacement?) {
     var placementValue = "none"

--- a/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
+++ b/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
@@ -78,10 +78,7 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
   }
 
   func body(content: Content) -> some View {
-    #if os(macOS)
-    // tabViewBottomAccessory is not available on macOS
-    content
-    #else
+    #if compiler(>=6.1) && !os(macOS)
     if #available(iOS 26.0, tvOS 26.0, visionOS 3.0, *), bottomAccessoryView != nil {
       content
         .tabViewBottomAccessory {
@@ -90,12 +87,14 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
     } else {
       content
     }
+    #else
+    content
     #endif
   }
 
   @ViewBuilder
   private func renderBottomAccessoryView() -> some View {
-    #if !os(macOS)
+    #if compiler(>=6.1) && !os(macOS)
     if let bottomAccessoryView {
       if #available(iOS 26.0, *) {
         BottomAccessoryRepresentableView(view: bottomAccessoryView)
@@ -105,7 +104,7 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
   }
 }
 
-#if !os(macOS)
+#if compiler(>=6.1) && !os(macOS)
 @available(iOS 26.0, *)
 struct BottomAccessoryRepresentableView: PlatformViewRepresentable {
   @Environment(\.tabViewBottomAccessoryPlacement) var tabViewBottomAccessoryPlacement


### PR DESCRIPTION
## Problem

Builds fail on Xcode 16.x (Swift 5.10) because `TabViewBottomAccessoryPlacement`, `.tabViewBottomAccessory`, and `\.tabViewBottomAccessoryPlacement` are iOS 26 APIs that the compiler cannot resolve — even inside `@available(iOS 26.0, *)` blocks. The `@available` attribute is a runtime check; the compiler still needs to parse and type-check the code at compile time.
PR #486 partially addressed this for macOS with `#if !os(macOS)`, but the same issue affects iOS when using any Xcode version prior to Xcode 26.

## Solution

Replace `#if !os(macOS)` with `#if compiler(>=6.1) && !os(macOS)` in both `BottomAccessoryProvider.swift` and `NewTabView.swift`. Swift 6.1 ships with Xcode 26, so this ensures the iOS 26 API references are only compiled when the toolchain actually supports them.

## Changes

- `BottomAccessoryProvider.swift`: `#if !os(macOS)` → `#if compiler(>=6.1) && !os(macOS)`
- `NewTabView.swift`: All `#if !os(macOS)` and `#if os(macOS)` guards around iOS 26 code → `#if compiler(>=6.1) && !os(macOS)` / `#else`
Fixes #490
